### PR TITLE
Add filter for ddhcpd multicast

### DIFF
--- a/contrib/filters/bcast-stats.rules.BCAST
+++ b/contrib/filters/bcast-stats.rules.BCAST
@@ -13,6 +13,7 @@ IPv6_fragment,ipv6.nxt == 44
 IPv4_fragment,ip.flags.mf == 1 || ip.frag_offset > 0
 DHCP,bootp
 DHCPv6,udp.dstport == 547
+DDHCPD,ipv6.addr eq ff02::1234
 XID,llc.control == 0x00af
 BJNP,bjnp
 ws-discovery,udp.dstport == 3702


### PR DESCRIPTION
Preparation for our mesh wide ddhcpd deployment. Our goal is to observe the multicast noise ddhcpd is producing. And compare it to the dhcp broadcast noise.